### PR TITLE
Remove DoesS3BucketExistV2Async call that need ACL

### DIFF
--- a/src/Our.Umbraco.StorageProviders.AWSS3/Imaging/AWSS3FileSystemImageProvider.cs
+++ b/src/Our.Umbraco.StorageProviders.AWSS3/Imaging/AWSS3FileSystemImageProvider.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Threading.Tasks;
 using Amazon.S3;
-using Amazon.S3.Util;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.Extensions.Options;
@@ -96,11 +95,7 @@ namespace Our.Umbraco.StorageProviders.AWSS3.Imaging
         private async Task<IImageResolver?> GetResolverAsync(HttpContext context)
         {
             var fileSystemProvider = _fileSystemProvider.GetFileSystem(_name);
-
-            if (await AmazonS3Util.DoesS3BucketExistV2Async(_s3Client, _bucketName))
-                return new AWSS3StorageImageResolver(_s3Client, _bucketName, fileSystemProvider.ResolveBucketPath(context.Request.Path));
-
-            return null;
+            return new AWSS3StorageImageResolver(_s3Client, _bucketName, fileSystemProvider.ResolveBucketPath(context.Request.Path));
         }
 
         /// <inheritdoc />

--- a/src/Our.Umbraco.StorageProviders.AWSS3/Our.Umbraco.StorageProviders.AWSS3.csproj
+++ b/src/Our.Umbraco.StorageProviders.AWSS3/Our.Umbraco.StorageProviders.AWSS3.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title>Umbraco AWS S3 Storage Provider</Title>
-    <Version>1.1.1</Version>
+    <Version>1.3.1</Version>
     <Copyright>2022</Copyright>
     <Description>An implementation of the Umbraco IFileSystem connecting your Umbraco Media section to an AWS S3 Storage bucket featuring middleware serving up media files from the `/media` path and ImageSharp image provider/cache.</Description>
     <PackageTags>umbraco;aws;s3;umbraco;umbraco10;umbraco-marketplace</PackageTags>


### PR DESCRIPTION
S3 buckets have not been enabled ACL by default.
https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html

> A majority of modern use cases in Amazon S3 no longer require the use of ACLs. We recommend that you keep ACLs disabled, except in unusual circumstances where you need to control access for each object individually.

Can you disable DoesS3BucketExistV2Async call that needs ACL?