### PR TITLE
Added the ability to set the media bucket prefix from the app settings

### DIFF
--- a/src/Our.Umbraco.StorageProviders.AWSS3/AWSS3FileSystemMiddleware.cs
+++ b/src/Our.Umbraco.StorageProviders.AWSS3/AWSS3FileSystemMiddleware.cs
@@ -1,21 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Net;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading;
-using System.Threading.Tasks;
-using Amazon.S3;
+﻿using Amazon.S3;
 using Amazon.S3.Model;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
-using Umbraco.Cms.Core.Hosting;
 using Our.Umbraco.StorageProviders.AWSS3.IO;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Umbraco.Cms.Core.Hosting;
 
 namespace Our.Umbraco.StorageProviders.AWSS3
 {
@@ -64,7 +61,7 @@ namespace Our.Umbraco.StorageProviders.AWSS3
 
             var fileSystemOptions = options.Get(name);
             _rootPath = hostingEnvironment.ToAbsolute(fileSystemOptions.VirtualPath);
-            _containerRootPath = AWSS3FileSystemOptions.BucketPrefix ?? _rootPath;
+            _containerRootPath = fileSystemOptions.BucketPrefix ?? AWSS3FileSystemOptions.MediaBucketPrefix ?? _rootPath;
             _bucketName = fileSystemOptions.BucketName;
 
             _s3Client = s3Client;

--- a/src/Our.Umbraco.StorageProviders.AWSS3/IO/AWSS3FileSystem.cs
+++ b/src/Our.Umbraco.StorageProviders.AWSS3/IO/AWSS3FileSystem.cs
@@ -48,7 +48,7 @@ namespace Our.Umbraco.StorageProviders.AWSS3.IO
             _bucketName = options.BucketName ?? throw new ArgumentNullException(nameof(contentTypeProvider));
 
             _rootUrl = EnsureUrlSeparatorChar(hostingEnvironment.ToAbsolute(options.VirtualPath)).TrimEnd('/');
-            _bucketPrefix = AWSS3FileSystemOptions.BucketPrefix ?? _rootUrl;
+            _bucketPrefix = options.BucketPrefix ?? AWSS3FileSystemOptions.MediaBucketPrefix ?? _rootUrl;
             _cannedACL = options.CannedACL;
             _serverSideEncryptionMethod = options.ServerSideEncryptionMethod;
             _rootPath = hostingEnvironment.ToAbsolute(options.VirtualPath);

--- a/src/Our.Umbraco.StorageProviders.AWSS3/IO/AWSS3FileSystemOptions.cs
+++ b/src/Our.Umbraco.StorageProviders.AWSS3/IO/AWSS3FileSystemOptions.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Amazon.S3;
 using System.ComponentModel.DataAnnotations;
-using System.Text;
-using Amazon.S3;
 
 namespace Our.Umbraco.StorageProviders.AWSS3.IO
 {
@@ -16,7 +13,7 @@ namespace Our.Umbraco.StorageProviders.AWSS3.IO
         /// <summary>
         /// The prefix for the media files name string.
         /// </summary>
-        public const string BucketPrefix = "media";
+        public const string MediaBucketPrefix = "media";
 
         /// <summary>
         /// The region for the bucket
@@ -29,6 +26,7 @@ namespace Our.Umbraco.StorageProviders.AWSS3.IO
         /// </summary>
         [Required]
         public string BucketName { get; set; } = null!;
+        public string BucketPrefix { get; set; } = MediaBucketPrefix;
 
         /// <summary>
         /// The virtual path.


### PR DESCRIPTION
This PR allows you to override the bucket prefix using the file system options from the app settings.  Currently, you cannot do this and all buckets prefixes have to be called **media**.  We had a requirement to use a different prefix in the same bucket as the media for another purpose so we needed a way of overriding this.

An example config for this is:

    "Storage": {
      "AWSS3": {
        "Media": {
          "BucketName": "bucket-name-goes-here"
        },
        "Files": {
          "BucketName": "bucket-name-goes-here",
          "BucketPrefix": "files"
        }
      }
    }

I thought this was a useful contribution so hoping you merge into the package for others.

If not set it will default to **media** as it does now.