### PR TITLE
Add ServiceURL configuration option

### DIFF
--- a/src/Our.Umbraco.StorageProviders.AWSS3/DependencyInjection/AWSS3MediaFileSystemExtensions.cs
+++ b/src/Our.Umbraco.StorageProviders.AWSS3/DependencyInjection/AWSS3MediaFileSystemExtensions.cs
@@ -47,6 +47,9 @@ namespace Our.Umbraco.StorageProviders.AWSS3.DependencyInjection
             // ImageSharp image provider/cache
             builder.Services.Insert(0, ServiceDescriptor.Singleton<IImageProvider, AWSS3FileSystemImageProvider>());
             builder.Services.AddUnique<IImageCache, AWSS3FileSystemImageCache>();
+            builder.Services.AddOptions<AWSS3StorageCacheOptions>(AWSS3FileSystemOptions.MediaFileSystemName);
+            builder.Services
+                .AddSingleton<IConfigureOptions<AWSS3StorageCacheOptions>, AWSS3FileSystemImageCacheConfigureOptions>();
 
             builder.SetMediaFileSystem(provider => provider.GetRequiredService<IAWSS3FileSystemProvider>()
                 .GetFileSystem(AWSS3FileSystemOptions.MediaFileSystemName));

--- a/src/Our.Umbraco.StorageProviders.AWSS3/Imaging/AWSS3FileSystemImageCache.cs
+++ b/src/Our.Umbraco.StorageProviders.AWSS3/Imaging/AWSS3FileSystemImageCache.cs
@@ -23,16 +23,14 @@ namespace Our.Umbraco.StorageProviders.AWSS3.Imaging
     {
         private const string _cachePath = "cache/";
         private readonly string _name;
-        private AWSS3StorageCache baseCache = null;
-        private readonly IConfiguration _configuration;
-        private readonly IAmazonS3 _s3Client;
+        private AWSS3StorageCache baseCache;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AWSS3FileSystemImageCache" /> class.
         /// </summary>
         /// <param name="options">The options.</param>
-        public AWSS3FileSystemImageCache(IOptionsMonitor<AWSS3FileSystemOptions> options, IConfiguration configuration, IAmazonS3 s3Client)
-            : this(AWSS3FileSystemOptions.MediaFileSystemName, options, configuration, s3Client)
+        public AWSS3FileSystemImageCache(IOptionsMonitor<AWSS3StorageCacheOptions> options)
+            : this(AWSS3FileSystemOptions.MediaFileSystemName, options)
         {
         }
 
@@ -44,29 +42,11 @@ namespace Our.Umbraco.StorageProviders.AWSS3.Imaging
         /// <exception cref="System.ArgumentNullException">options
         /// or
         /// name</exception>
-        protected AWSS3FileSystemImageCache(string name, IOptionsMonitor<AWSS3FileSystemOptions> options, IConfiguration configuration, IAmazonS3 s3Client)
+        protected AWSS3FileSystemImageCache(string name, IOptionsMonitor<AWSS3StorageCacheOptions> options)
         {
             _name = name ?? throw new ArgumentNullException(nameof(name));
-
-            if (options == null) throw new ArgumentNullException(nameof(options));
-
-            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
-            _configuration = configuration;
-
-            _s3Client = s3Client;
-
-
-            // Collect configurations
-            var fileSystemOptions = options.Get(name);
-
-            // Bucket name comes from the AWSFileSystemOptions - BucketName is required in appsettings
-            string bucketName = fileSystemOptions.BucketName;
-
             
-            AWSOptions awsOptions = _configuration.GetAWSOptions();
-            AWSS3StorageCacheOptions cacheOptions = getAWSS3StorageCacheOptions(fileSystemOptions, awsOptions);
-
-            baseCache = new AWSS3StorageCache(Options.Create(cacheOptions));
+            baseCache = new AWSS3StorageCache(Options.Create(options.Get(_name)));
 
             options.OnChange(OptionsOnChange);
         }
@@ -86,65 +66,16 @@ namespace Our.Umbraco.StorageProviders.AWSS3.Imaging
             return baseCache.SetAsync(cacheAndKey, stream, metadata);
         }
 
-
-        private void OptionsOnChange(AWSS3FileSystemOptions options, string name)
+        private void OptionsOnChange(AWSS3StorageCacheOptions options, string name)
         {
             if (name != _name) return;
-
-            AWSOptions awsOptions = _configuration.GetAWSOptions();
-            var cacheOptions = getAWSS3StorageCacheOptions(options, awsOptions);
-
-            baseCache = new AWSS3StorageCache(Options.Create(cacheOptions));
+            
+            baseCache = new AWSS3StorageCache(Options.Create(options));
         }
 
+        
 
-        private string getRegionName(AWSS3FileSystemOptions options)
-        {
-            // Get region -- start with fileSystemOptions; Doesn't exist? fallback to AWSOptions and then to S3Client
-            string region = options.Region;
-            if (string.IsNullOrEmpty(region))
-            {
-                AWSOptions awsOptions = _configuration.GetAWSOptions();
-                if (awsOptions != null && awsOptions.Region != null)
-                {
-                    region = awsOptions.Region.SystemName;
-                }
-                else if (_s3Client != null)
-                {
-                    region = _s3Client.Config?.RegionEndpoint?.SystemName;
-                }
-            }
 
-            return region;
-        }
-
-        /// <summary>
-        /// Return AWSS3StorageCacheOptions object with logic to check the ProfilesLocation and use that in an override
-        /// as the client may want to target an alternative location
-        /// </summary>
-        /// <param name="awss3FileSystemOptions"></param>
-        /// <param name="awsOptions"></param>
-        /// <returns></returns>
-        private AWSS3StorageCacheOptions getAWSS3StorageCacheOptions(AWSS3FileSystemOptions awss3FileSystemOptions, AWSOptions awsOptions)
-        {
-            AWSS3StorageCacheOptions cacheOptions = new AWSS3StorageCacheOptions
-            {
-                BucketName = awss3FileSystemOptions.BucketName,
-                Region = getRegionName(awss3FileSystemOptions)
-            };
-
-            // if ProfilesLocation added, physical assignment of the AWS credentials must be made
-            if (!string.IsNullOrEmpty(awsOptions.ProfilesLocation))
-            {
-                var chain = new CredentialProfileStoreChain(awsOptions.ProfilesLocation);
-                if (chain.TryGetAWSCredentials(awsOptions.Profile, out AWSCredentials awsCredentials))
-                {
-                    cacheOptions.AccessKey = awsCredentials.GetCredentials().AccessKey;
-                    cacheOptions.AccessSecret = awsCredentials.GetCredentials().SecretKey;
-                }
-            }
-
-            return cacheOptions;
-        }
+        
     }
 }

--- a/src/Our.Umbraco.StorageProviders.AWSS3/Imaging/AWSS3FileSystemImageCacheConfigureOptions.cs
+++ b/src/Our.Umbraco.StorageProviders.AWSS3/Imaging/AWSS3FileSystemImageCacheConfigureOptions.cs
@@ -55,6 +55,9 @@ public class AWSS3FileSystemImageCacheConfigureOptions : IConfigureNamedOptions<
 
         cacheOptions.BucketName = awss3FileSystemOptions.BucketName;
         cacheOptions.Region = getRegionName(awss3FileSystemOptions, _awsOptions);
+        
+        if (string.IsNullOrEmpty(cacheOptions.Region))
+            cacheOptions.Endpoint = _s3Client.Config.ServiceURL;
 
         // if ProfilesLocation added, physical assignment of the AWS credentials must be made
         if (!string.IsNullOrEmpty(_awsOptions.ProfilesLocation))

--- a/src/Our.Umbraco.StorageProviders.AWSS3/Imaging/AWSS3FileSystemImageCacheConfigureOptions.cs
+++ b/src/Our.Umbraco.StorageProviders.AWSS3/Imaging/AWSS3FileSystemImageCacheConfigureOptions.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using Amazon.Extensions.NETCore.Setup;
+using Amazon.Runtime;
+using Amazon.Runtime.CredentialManagement;
+using Amazon.S3;
+using Dazinator.Extensions.FileProviders;
+using J2N.Collections.ObjectModel;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using NPoco.Expressions;
+using Our.Umbraco.StorageProviders.AWSS3.IO;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Web.Caching.AWS;
+
+namespace Our.Umbraco.StorageProviders.AWSS3.Imaging;
+
+public class AWSS3FileSystemImageCacheConfigureOptions : IConfigureNamedOptions<AWSS3StorageCacheOptions>
+{
+    private readonly string _name = AWSS3FileSystemOptions.MediaFileSystemName;
+    private readonly IOptionsMonitor<AWSS3FileSystemOptions> _fileSystemOptions;
+    private readonly AWSOptions _awsOptions;
+    private readonly IAmazonS3 _s3Client;
+    
+    public AWSS3FileSystemImageCacheConfigureOptions(
+        IOptionsMonitor<AWSS3FileSystemOptions> fileSystemOptions,
+        AWSOptions awsOptions, 
+        IAmazonS3 s3Client)
+    {
+        _fileSystemOptions = fileSystemOptions ?? throw new ArgumentNullException(nameof(fileSystemOptions));
+        _awsOptions = awsOptions ?? throw new ArgumentNullException(nameof(awsOptions));
+        _s3Client = s3Client;
+    }
+    
+    public void Configure(AWSS3StorageCacheOptions options)
+    {
+        Configure(Options.DefaultName, options);
+    }
+ 
+    /// <summary>
+    /// Return AWSS3StorageCacheOptions object with logic to check the ProfilesLocation and use that in an override
+    /// as the client may want to target an alternative location
+    /// </summary>
+    public void Configure(string name, AWSS3StorageCacheOptions cacheOptions)
+    {
+        if (name != _name)
+            return;
+
+        var awss3FileSystemOptions = this._fileSystemOptions.Get(this._name);
+
+        cacheOptions.BucketName = awss3FileSystemOptions.BucketName;
+        cacheOptions.Region = getRegionName(awss3FileSystemOptions, _awsOptions);
+
+        // if ProfilesLocation added, physical assignment of the AWS credentials must be made
+        if (!string.IsNullOrEmpty(_awsOptions.ProfilesLocation))
+        {
+            var chain = new CredentialProfileStoreChain(_awsOptions.ProfilesLocation);
+            if (chain.TryGetAWSCredentials(_awsOptions.Profile, out AWSCredentials awsCredentials))
+            {
+                cacheOptions.AccessKey = awsCredentials.GetCredentials().AccessKey;
+                cacheOptions.AccessSecret = awsCredentials.GetCredentials().SecretKey;
+            }
+        }
+    }
+    
+    private string getRegionName(AWSS3FileSystemOptions options, AWSOptions awsOptions)
+    {
+        // Get region -- start with fileSystemOptions; Doesn't exist? fallback to AWSOptions and then to S3Client
+        string region = options.Region;
+        if (string.IsNullOrEmpty(region))
+        {
+            if (awsOptions != null && awsOptions.Region != null)
+            {
+                region = awsOptions.Region.SystemName;
+            }
+            else if (_s3Client != null)
+            {
+                region = _s3Client.Config?.RegionEndpoint?.SystemName;
+            }
+        }
+
+        return region;
+    }
+}


### PR DESCRIPTION
Adding the following to allow the ServiceURL configuration option as follows:

```
if (string.IsNullOrEmpty(cacheOptions.Region))
            cacheOptions.Endpoint = _s3Client.Config.ServiceURL;
```

This allows for use of the library with buckets that use the S3 protocol but are hosted elsewhere. I'm using it in projects that run inside a self-hosted Kubernetes cluster and use [Noobaa](https://www.noobaa.io/) to provide abstracted blob storage using the S3 protocol.

This PR also refactors the configuration for the `AWSS3StorageCacheOptions` using the named configuration options pattern, to reduce the amount of code in the `AWSS3FileSystemImageCache` file.
